### PR TITLE
Add support for ansible-parity in html format.

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -188,16 +188,21 @@ def main():
             'missing_kubernetes_fixes',
             'missing_puppet_fixes',
             'missing_anaconda_fixes',
-            'missing_cces'
+            'missing_cces',
+            'ansible_parity'
             ]
         link = """<a href="{}"><div style="height:100%;width:100%">{}</div></a>"""
 
         for profile in ret:
+            bash_fixes_count = profile['rules_count'] - profile['missing_bash_fixes_count']
             for content in content_list:
                 content_file = "{}_{}.txt".format(profile['profile_id'], content)
                 content_filepath = os.path.join("content", content_file)
                 count = len(profile[content])
                 if count > 0:
+                    if content == "ansible_parity":
+                        #custom text link for ansible parity
+                        count = link.format(content_filepath, "{} out of {} ({}%)".format(bash_fixes_count-count, bash_fixes_count, int(((bash_fixes_count-count)/bash_fixes_count)*100)))
                     count_href_element = link.format(content_filepath, count)
                     profile['{}_count'.format(content)] = count_href_element
                     with open(os.path.join(content_path, content_file), 'w+') as f:

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -460,8 +460,8 @@ class XCCDFBenchmark(object):
                                    console_width)
 
             if options.ansible_parity:
-                print("*** rules of '%s' profile with bash fix which miss "
-                      "ansible fix scripts: %d of %d [%d%% complete]"
+                print("*** rules of '%s' profile with bash fix that implement "
+                      "ansible fix scripts: %d out of %d [%d%% complete]"
                       % (profile, impl_bash_fixes_count - len(profile_stats['ansible_parity']),
                          impl_bash_fixes_count,
                          profile_stats['ansible_parity_pct']))
@@ -498,6 +498,7 @@ class XCCDFBenchmark(object):
             del profile_stats['implemented_anaconda_fixes_pct']
             del profile_stats['assigned_cces_pct']
             del profile_stats['ssg_version']
+            del profile_stats['ansible_parity_pct']
 
             return profile_stats
         else:


### PR DESCRIPTION
#### Description:

- Implement HTML ansible parity statistics so it will show up in the jenkins job: https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/

To build the html you can run:
```
$ cd build
$ cmake ..
$ make rhel8-html-profile-stats
$ firefox rhel8/profile-statistics/statistics.html

```
So far it shows an HTML page containing the following table snippet

![ansible_parity](https://user-images.githubusercontent.com/18730394/85310297-0b9a5c80-b4b4-11ea-921a-e52bd48b9965.png)