### PR TITLE
Fix jinja variable definition in configure_firewalld_ports bash.

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/bash/shared.sh
@@ -10,12 +10,6 @@
 
 {{{ bash_instantiate_variables("firewalld_sshd_zone") }}}
 
-{{% if product in ['rhel9'] %}}
-  {{% set network_config_path = "/etc/NetworkManager/system-connections/${eth_interface_list[0]}.nmconnection" %}}
-{{% else %}}
-  {{% set network_config_path = "/etc/sysconfig/network-scripts/ifcfg-${eth_interface_list[0]}" %}}
-{{% endif %}}
-
 # This assumes that firewalld_sshd_zone is one of the pre-defined zones
 if [ ! -f /etc/firewalld/zones/${firewalld_sshd_zone}.xml ]; then
     cp /usr/lib/firewalld/zones/${firewalld_sshd_zone}.xml /etc/firewalld/zones/${firewalld_sshd_zone}.xml
@@ -28,6 +22,13 @@ fi
 # Check if any eth interface is bounded to the zone with SSH service enabled
 nic_bound=false
 eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
+
+{{% if product in ['rhel9'] %}}
+  {{% set network_config_path = "/etc/NetworkManager/system-connections/${eth_interface_list[0]}.nmconnection" %}}
+{{% else %}}
+  {{% set network_config_path = "/etc/sysconfig/network-scripts/ifcfg-${eth_interface_list[0]}" %}}
+{{% endif %}}
+
 for interface in $eth_interface_list; do
     if grep -qi "ZONE=$firewalld_sshd_zone" {{{ network_config_path }}}; then
         nic_bound=true


### PR DESCRIPTION
#### Description:
- eth_interface_list is only define in line `eth_interface_list=$(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')`

Problem introduced in: https://github.com/ComplianceAsCode/content/commit/17c5a4e3aac7f5253e488faea3145b3a7b5f41ec#diff-a66bf1f3905282fdb8a7d99948bc901481820ccb3e48cbbfb12313ee5ffa2e90

I still haven't tested but noticed this inconsistency.
